### PR TITLE
I6 brownian timestep

### DIFF
--- a/stochrare/dynamics/diffusion.py
+++ b/stochrare/dynamics/diffusion.py
@@ -206,7 +206,7 @@ class DiffusionProcess:
         else:
             deltat = kwargs.pop('deltat', dt)
             ratio = int(np.rint(dt/deltat))
-            dw = np.random.normal(0, np.sqrt(dt), size=(num-1, dim))
+            dw = np.random.normal(0, np.sqrt(deltat), size=(num-1, dim))
         dw = self._integrate_brownian_path(dw, num, dim, ratio)
         x = self._euler_maruyama(x, tarray, dw, dt, self.drift, self.diffusion)
         if kwargs.get('finite', False):

--- a/stochrare/dynamics/diffusion.py
+++ b/stochrare/dynamics/diffusion.py
@@ -206,7 +206,7 @@ class DiffusionProcess:
         else:
             deltat = kwargs.pop('deltat', dt)
             ratio = int(np.rint(dt/deltat))
-            dw = np.random.normal(0, np.sqrt(deltat), size=(num-1, dim))
+            dw = np.random.normal(0, np.sqrt(deltat), size=((num-1)*ratio, dim))
 
             # As of numpy 1.18, random.normal does not support setting the dtype of
             # the returned array (https://github.com/numpy/numpy/issues/10892).

--- a/stochrare/dynamics/diffusion.py
+++ b/stochrare/dynamics/diffusion.py
@@ -191,7 +191,7 @@ class DiffusionProcess:
         dt = kwargs.get('dt', self.default_dt) # Time step
         time = kwargs.get('T', 10.0)   # Total integration time
         if dt < 0:
-            time = -time
+            raise ValueError("Timestep dt cannot be negative")
         precision = kwargs.pop('precision', np.float32)
         dim = len(x0)
         num = int(time/dt)+1

--- a/stochrare/dynamics/diffusion.py
+++ b/stochrare/dynamics/diffusion.py
@@ -127,6 +127,37 @@ class DiffusionProcess:
         dw = kwargs.get('dw', np.random.normal(0.0, np.sqrt(dt), dim))
         return xn + self.drift(xn, tn)*dt+self.diffusion(xn, tn)@dw
 
+
+    @staticmethod
+    def _integrate_brownian_path(dw, num, dim, ratio):
+        """
+        Return piece-wise integrated brownian path.
+
+        Parameters
+        ----------
+        dw: ndarray
+          Brownian path.
+        num: int
+          Number of SDE timesteps.
+        dim: int
+          Brownian path dimension.
+        ratio: int
+          Ratio between brownian path timestep and SDE timestep.
+
+        Returns
+        -------
+        integrated_dw: ndarray
+          Piecewise integrated brownian path.
+        """
+
+        expected_shape = ((num-1)*ratio, dim)
+        if not dw.shape == expected_shape:
+            raise ValueError("Brownian path array has dimension {}, expected {}".format(dw.shape, expected_shape))
+        integrated_dw = np.zeros((num-1, dim), dtype=dw.dtype)
+        for coord in range(dim):
+            integrated_dw[:,coord] = dw[:,coord].reshape((num-1, ratio)).sum(axis=1)
+        return integrated_dw
+
     @pseudorand
     def trajectory(self, x0, t0, **kwargs):
         r"""
@@ -159,6 +190,8 @@ class DiffusionProcess:
         x = [x0]
         dt = kwargs.get('dt', self.default_dt) # Time step
         time = kwargs.get('T', 10.0)   # Total integration time
+        if dt < 0:
+            time = -time
         precision = kwargs.pop('precision', np.float32)
         dim = len(x0)
         num = int(time/dt)+1
@@ -167,8 +200,14 @@ class DiffusionProcess:
         if 'brownian_path' in kwargs:
             tw, w = kwargs.pop('brownian_path')
             dw = np.diff(w, axis=0)
+            deltat = tw[1]-tw[0]
+            ratio = int(np.rint(dt/deltat)) # Both int and rint needed here ?
+            dw = dw[:((num-1)*ratio)] # Trim noise vector if sequence w too long
         else:
+            deltat = kwargs.pop('deltat', dt)
+            ratio = int(np.rint(dt/deltat))
             dw = np.random.normal(0, np.sqrt(dt), size=(num-1, dim))
+        dw = self._integrate_brownian_path(dw, num, dim, ratio)
         x = self._euler_maruyama(x, tarray, dw, dt, self.drift, self.diffusion)
         if kwargs.get('finite', False):
             tarray = tarray[np.isfinite(x)]

--- a/stochrare/tests/test_diffusion.py
+++ b/stochrare/tests/test_diffusion.py
@@ -77,6 +77,41 @@ class TestDynamics(unittest.TestCase):
         np.testing.assert_allclose(traj[1][:, 0], traj_exact1[::2], rtol=1e-2)
         np.testing.assert_allclose(traj[1][:, 1], traj_exact2[::2], rtol=1e-2)
 
+    def test_trajectory_compute_brownian_path(self):
+        dt_brownian = 1e-5
+        for dtype in [np.float32, np.float64]:
+            diff = lambda x, t: np.array([[x[0], 0], [0, x[1]]], dtype=dtype)
+            model = diffusion.DiffusionProcess(lambda x, t: 2*x, diff, deterministic=True)
+            traj = model.trajectory(np.array([1., 1.]), 0., T=0.1, dt=dt_brownian, precision=dtype)
+
+            brownian_path = self.wiener.trajectory(np.array([0., 0.]), 0., T=0.1, dt=dt_brownian)
+            traj_exact1 = np.exp(1.5*brownian_path[0]+brownian_path[1][:, 0])
+            traj_exact2 = np.exp(1.5*brownian_path[0]+brownian_path[1][:, 1])
+
+            np.testing.assert_allclose(traj[1][:, 0], traj_exact1, rtol=1e-2)
+            np.testing.assert_allclose(traj[1][:, 1], traj_exact2, rtol=1e-2)
+
+
+    def test_trajectory_compute_brownian_path_lower_timestep(self):
+        dt_brownian = 1e-5
+        for dtype in [np.float32, np.float64]:
+            with self.subTest(dtype=dtype):
+                diff = lambda x, t: np.array([[x[0], 0], [0, x[1]]], dtype=dtype)
+                model = diffusion.DiffusionProcess(lambda x, t: 2*x, diff, deterministic=True)
+                traj = model.trajectory(np.array([1., 1.]), 0.,
+                                        T=0.1,
+                                        dt=2*dt_brownian,
+                                        deltat=dt_brownian,
+                                        precision=dtype,
+                )
+
+                brownian_path = self.wiener.trajectory(np.array([0., 0.]), 0., T=0.1, dt=dt_brownian)
+                traj_exact1 = np.exp(1.5*brownian_path[0]+brownian_path[1][:, 0])
+                traj_exact2 = np.exp(1.5*brownian_path[0]+brownian_path[1][:, 1])
+
+                np.testing.assert_allclose(traj[1][:, 0], traj_exact1[::2], rtol=1e-2)
+                np.testing.assert_allclose(traj[1][:, 1], traj_exact2[::2], rtol=1e-2)
+
     def test_trajectory_generator(self):
         traj = np.array([x for t, x in self.oup.trajectory_generator(np.array([0, 0]), 0,
                                                                      100, dt=0.01)])

--- a/stochrare/tests/test_diffusion.py
+++ b/stochrare/tests/test_diffusion.py
@@ -53,7 +53,7 @@ class TestDynamics(unittest.TestCase):
         solution_array = np.array([[6,27],[15,18], [24,9]])
         np.testing.assert_array_equal(integrated_dw, solution_array)
 
-    def test_trajectory(self):
+    def test_trajectory_same_timestep(self):
         dt_brownian = 1e-5
         diff = lambda x, t: np.array([[x[0], 0], [0, x[1]]], dtype=np.float32)
         model = diffusion.DiffusionProcess(lambda x, t: 2*x, diff, deterministic=True)
@@ -64,6 +64,18 @@ class TestDynamics(unittest.TestCase):
                                 brownian_path=brownian_path, precision=np.float32)
         np.testing.assert_allclose(traj[1][:, 0], traj_exact1, rtol=1e-2)
         np.testing.assert_allclose(traj[1][:, 1], traj_exact2, rtol=1e-2)
+
+    def test_trajectory_lower_timestep(self):
+        dt_brownian = 1e-5
+        diff = lambda x, t: np.array([[x[0], 0], [0, x[1]]], dtype=np.float32)
+        model = diffusion.DiffusionProcess(lambda x, t: 2*x, diff, deterministic=True)
+        brownian_path = self.wiener.trajectory(np.array([0., 0.]), 0., T=0.1, dt=dt_brownian)
+        traj_exact1 = np.exp(1.5*brownian_path[0]+brownian_path[1][:, 0])
+        traj_exact2 = np.exp(1.5*brownian_path[0]+brownian_path[1][:, 1])
+        traj = model.trajectory(np.array([1., 1.]), 0., T=0.1, dt=2*dt_brownian,
+                                brownian_path=brownian_path, precision=np.float32)
+        np.testing.assert_allclose(traj[1][:, 0], traj_exact1[::2], rtol=1e-2)
+        np.testing.assert_allclose(traj[1][:, 1], traj_exact2[::2], rtol=1e-2)
 
     def test_trajectory_generator(self):
         traj = np.array([x for t, x in self.oup.trajectory_generator(np.array([0, 0]), 0,

--- a/stochrare/tests/test_diffusion.py
+++ b/stochrare/tests/test_diffusion.py
@@ -39,6 +39,20 @@ class TestDynamics(unittest.TestCase):
         x = np.zeros(self.wiener.dimension)
         np.testing.assert_array_equal(self.wiener.update(x, 0, dw=dw), dw)
 
+    def test_integrate_brownian_path(self):
+        num = 4
+        dim = 2
+        ratio = 3
+
+        dw_wrong_shape = np.array([range(1,11), range(11,1,-1)]).transpose()
+        with self.assertRaises(ValueError):
+            diffusion.DiffusionProcess._integrate_brownian_path(dw_wrong_shape, num, dim, ratio)
+
+        dw_correct_shape = np.array([range(1,10), range(10,1,-1)]).transpose()
+        integrated_dw = diffusion.DiffusionProcess._integrate_brownian_path(dw_correct_shape, num, dim, ratio)
+        solution_array = np.array([[6,27],[15,18], [24,9]])
+        np.testing.assert_array_equal(integrated_dw, solution_array)
+
     def test_trajectory(self):
         dt_brownian = 1e-5
         diff = lambda x, t: np.array([[x[0], 0], [0, x[1]]], dtype=np.float32)

--- a/stochrare/tests/test_diffusion.py
+++ b/stochrare/tests/test_diffusion.py
@@ -53,10 +53,16 @@ class TestDynamics(unittest.TestCase):
         solution_array = np.array([[6,27],[15,18], [24,9]])
         np.testing.assert_array_equal(integrated_dw, solution_array)
 
+
     def test_trajectory_same_timestep(self):
         dt_brownian = 1e-5
         diff = lambda x, t: np.array([[x[0], 0], [0, x[1]]], dtype=np.float32)
         model = diffusion.DiffusionProcess(lambda x, t: 2*x, diff, deterministic=True)
+
+        # Check that ValueError is raised if negative timestep dt
+        with self.assertRaises(ValueError):
+            traj = model.trajectory(np.array([1., 1.]), 0., T=0.1, dt=-1)
+
         brownian_path = self.wiener.trajectory(np.array([0., 0.]), 0., T=0.1, dt=dt_brownian)
         traj_exact1 = np.exp(1.5*brownian_path[0]+brownian_path[1][:, 0])
         traj_exact2 = np.exp(1.5*brownian_path[0]+brownian_path[1][:, 1])


### PR DESCRIPTION
This PR allows `DiffusionProcess` trajectories to be generated with a timestep `dt` greater that the brownian path `deltat`.

Note that the piece-wise integration of the brownian path prior to integration is now performed in a 
separate method `DiffusionProcess._integrate_brownian_path`, allowing unit testing.

Addresses #6 