### PR TITLE
I7 euler maruyama dimension

### DIFF
--- a/stochrare/dynamics/diffusion.py
+++ b/stochrare/dynamics/diffusion.py
@@ -263,6 +263,17 @@ class DiffusionProcess:
         return x
 
 
+    @staticmethod
+    @jit(nopython=True)
+    def _euler_maruyama_1d(x, t, w, dt, drift, diffusion):
+        for index in range(1, len(w)+1):
+            wn = w[index-1]
+            xn = x[index-1]
+            tn = t[index-1]
+            x[index] = xn + drift(xn, tn)*dt + diffusion(xn, tn)*wn
+        return x
+
+
     @pseudorand
     def trajectory_generator(self, x0, t0, nsteps, **kwargs):
         r"""

--- a/stochrare/dynamics/diffusion.py
+++ b/stochrare/dynamics/diffusion.py
@@ -154,12 +154,10 @@ class DiffusionProcess:
            "Numerical solution of stochastic differential equations", Springer (1992).
         """
         dt = kwargs.get('dt', self.default_dt)
-        if type(xn) in [int, float]:
-            xn = np.array([xn])
+        xn = np.atleast_1d(xn)
         dim = len(xn)
         dw = kwargs.get('dw', np.random.normal(0.0, np.sqrt(dt), dim))
-        if type(dw) in [int, float]:
-            dw = np.array([dw])
+        dw = np.atleast_1d(dw)
         return xn + self.drift(xn, tn)*dt+self.diffusion(xn, tn)@dw
 
 
@@ -241,9 +239,7 @@ class DiffusionProcess:
         dt = kwargs.pop('dt', self.default_dt) # Time step
         time = kwargs.get('T', 10.0)   # Total integration time
         precision = kwargs.pop('precision', np.float32)
-
-        if type(x0) in [int, float]:
-            x0 = np.array([x0], dtype=precision)
+        x0 = np.atleast_1d(x0).astype(precision)
         dim = len(x0)
         num = int(time/dt)+1
         tarray = np.linspace(t0, t0+time, num=num, dtype=precision)
@@ -253,7 +249,6 @@ class DiffusionProcess:
             dw = np.diff(w, axis=0)
         else:
             dw = np.random.normal(0, np.sqrt(dt), size=(num-1, dim))
-
         x = self.integrate_sde(x, tarray, dw, dt=dt, **kwargs)
         if kwargs.get('finite', False):
             tarray = tarray[np.isfinite(x)]

--- a/stochrare/dynamics/diffusion.py
+++ b/stochrare/dynamics/diffusion.py
@@ -156,7 +156,7 @@ class DiffusionProcess:
         dt = kwargs.get('dt', self.default_dt)
         dim = len(xn)
         dw = kwargs.get('dw', np.random.normal(0.0, np.sqrt(dt), dim))
-        return self._euler_maruyama(xn, tn, wn, dt, self.drift, self.diffusion)
+        return xn + self.drift(xn, tn)*dt+self.diffusion(xn, tn)@dw
 
 
     def integrate_sde(self, x, t, w, **kwargs):
@@ -255,17 +255,12 @@ class DiffusionProcess:
     @staticmethod
     @jit(nopython=True)
     def _euler_maruyama(x, t, w, dt, drift, diffusion):
-        if w.ndim == 1:
-            # Test if w is just a vector
-            # In that case do only one EM iteration
-            return x + drift(x, t)*dt + np.dot(diffusion(x, t), w)
-        else:
-            for index in range(1, len(w)+1):
-                wn = w[index-1]
-                xn = x[index-1]
-                tn = t[index-1]
-                x[index] = xn + drift(xn, tn)*dt + np.dot(diffusion(xn, tn), wn)
-            return x
+        for index in range(1, len(w)+1):
+            wn = w[index-1]
+            xn = x[index-1]
+            tn = t[index-1]
+            x[index] = xn + drift(xn, tn)*dt + np.dot(diffusion(xn, tn), wn)
+        return x
 
 
     @pseudorand

--- a/stochrare/dynamics/diffusion.py
+++ b/stochrare/dynamics/diffusion.py
@@ -271,17 +271,6 @@ class DiffusionProcess:
         return x
 
 
-    @staticmethod
-    @jit(nopython=True)
-    def _euler_maruyama_1d(x, t, w, dt, drift, diffusion):
-        for index in range(1, len(w)+1):
-            wn = w[index-1]
-            xn = x[index-1]
-            tn = t[index-1]
-            x[index] = xn + drift(xn, tn)*dt + diffusion(xn, tn)*wn
-        return x
-
-
     @pseudorand
     def trajectory_generator(self, x0, t0, nsteps, **kwargs):
         r"""

--- a/stochrare/dynamics/diffusion.py
+++ b/stochrare/dynamics/diffusion.py
@@ -154,8 +154,12 @@ class DiffusionProcess:
            "Numerical solution of stochastic differential equations", Springer (1992).
         """
         dt = kwargs.get('dt', self.default_dt)
+        if type(xn) in [int, float]:
+            xn = np.array([xn])
         dim = len(xn)
         dw = kwargs.get('dw', np.random.normal(0.0, np.sqrt(dt), dim))
+        if type(dw) in [int, float]:
+            dw = np.array([dw])
         return xn + self.drift(xn, tn)*dt+self.diffusion(xn, tn)@dw
 
 
@@ -237,6 +241,9 @@ class DiffusionProcess:
         dt = kwargs.pop('dt', self.default_dt) # Time step
         time = kwargs.get('T', 10.0)   # Total integration time
         precision = kwargs.pop('precision', np.float32)
+
+        if type(x0) in [int, float]:
+            x0 = np.array([x0], dtype=precision)
         dim = len(x0)
         num = int(time/dt)+1
         tarray = np.linspace(t0, t0+time, num=num, dtype=precision)
@@ -246,6 +253,7 @@ class DiffusionProcess:
             dw = np.diff(w, axis=0)
         else:
             dw = np.random.normal(0, np.sqrt(dt), size=(num-1, dim))
+
         x = self.integrate_sde(x, tarray, dw, dt=dt, **kwargs)
         if kwargs.get('finite', False):
             tarray = tarray[np.isfinite(x)]

--- a/stochrare/tests/test_diffusion.py
+++ b/stochrare/tests/test_diffusion.py
@@ -108,5 +108,32 @@ class TestDynamics(unittest.TestCase):
         _, x = self.oup.trajectory(np.array([0, 0]), 0, dt=0.01, T=1)
         np.testing.assert_allclose(x, traj, rtol=1e-5)
 
+
+    def test_euler_maruyama(self):
+        x = diffusion.DiffusionProcess._euler_maruyama(
+            np.array([1,2,3]),
+            1.,
+            0.7*np.ones(3),
+            0.01,
+            lambda x, t: 2*x,
+            lambda x, t: np.diag(x) + t*np.eye(3),
+        )
+        np.testing.assert_almost_equal(x[0], 2.42)
+        np.testing.assert_almost_equal(x[1], 4.14)
+        np.testing.assert_almost_equal(x[2], 5.86)
+
+        x = diffusion.DiffusionProcess._euler_maruyama(
+            np.array([3,0,0]*4, dtype=np.float32).reshape(4,3),
+            np.array([1,2,3]),
+            1*np.ones((3,3)),
+            1.,
+            lambda x, t: 2*x,
+            lambda x, t: np.diag(x) + t*np.eye(3),
+        )
+        np.testing.assert_allclose(x[1], np.array([13., 1., 1.]))
+        np.testing.assert_allclose(x[2], np.array([54., 6., 6.]))
+        np.testing.assert_allclose(x[3], np.array([219., 27., 27.]))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/stochrare/tests/test_diffusion.py
+++ b/stochrare/tests/test_diffusion.py
@@ -103,7 +103,7 @@ class TestDynamics(unittest.TestCase):
     def test_trajectory(self):
         dt_brownian = 1e-5
         diff = lambda x, t: np.diag(x).astype(np.float32)
-        for dim in range(2,5):
+        for dim in range(1,5):
             with self.subTest(dim=dim):
                 model = diffusion.DiffusionProcess(lambda x, t: 2*x, diff, dim, deterministic=True)
                 wiener = diffusion.Wiener(dim, D=0.5, deterministic=True)
@@ -113,6 +113,18 @@ class TestDynamics(unittest.TestCase):
                 for coord in range(dim):
                     traj_exact = np.exp(1.5*brownian_path[0]+brownian_path[1][:, coord])
                     np.testing.assert_allclose(traj[1][:, coord], traj_exact, rtol=1e-2)
+
+
+    def test_trajectory_init_cond_as_scalar(self):
+        dt_brownian = 1e-5
+        diff = lambda x, t: np.diag(x).astype(np.float32)
+        model = diffusion.DiffusionProcess(lambda x, t: 2*x, diff, 1, deterministic=True)
+        wiener = diffusion.Wiener(1, D=0.5, deterministic=True)
+        brownian_path = wiener.trajectory(np.array([0.]), 0., T=0.1, dt=dt_brownian)
+        traj = model.trajectory(np.array([1.]), 0., T=0.1, dt=dt_brownian,
+                                brownian_path=brownian_path, precision=np.float32)
+        traj_exact = np.exp(1.5*brownian_path[0]+brownian_path[1][:, 0])
+        np.testing.assert_allclose(traj[1][:, 0], traj_exact, rtol=1e-2)
 
 
     def test_trajectory_generator(self):

--- a/stochrare/tests/test_diffusion.py
+++ b/stochrare/tests/test_diffusion.py
@@ -3,6 +3,7 @@ Unit tests for the diffusion module.
 """
 import unittest
 import numpy as np
+from numba import jit
 import stochrare.dynamics.diffusion as diffusion
 from unittest.mock import patch
 
@@ -112,18 +113,28 @@ class TestDynamics(unittest.TestCase):
         np.testing.assert_allclose(x, traj, rtol=1e-5)
 
 
-    def test_euler_maruyama(self):
-        x = diffusion.DiffusionProcess._euler_maruyama(
-            np.array([3,0,0]*4, dtype=np.float32).reshape(4,3),
-            np.array([1,2,3]),
-            1*np.ones((3,3)),
-            1.,
-            lambda x, t: 2*x,
-            lambda x, t: np.diag(x) + t*np.eye(3),
+    def test_euler_maruyama_1d(self):
+        x0 = 1.
+        x = diffusion.DiffusionProcess._euler_maruyama_1d(
+            np.array([x0]*4),
+            np.array(range(3)),
+            np.array([1.,2.,1.]),
+            0.1,
+            jit(lambda x, t: 2*x, nopython=True),
+            jit(lambda x, t: x + t, nopython=True),
         )
-        np.testing.assert_allclose(x[1], np.array([13., 1., 1.]))
-        np.testing.assert_allclose(x[2], np.array([54., 6., 6.]))
-        np.testing.assert_allclose(x[3], np.array([219., 27., 27.]))
+        np.testing.assert_allclose(x, np.array([1, 2.2, 9.04, 21.888]))
+
+        # x = diffusion.DiffusionProcess._euler_maruyama(
+        #     np.array([3,0,0]*4, dtype=np.float32).reshape(4,3),
+        #     np.array([1,2,3]),
+        #     1*np.ones((3,3)),
+        #     1.,
+
+        # )
+        # np.testing.assert_allclose(x[1], np.array([13., 1., 1.]))
+        # np.testing.assert_allclose(x[2], np.array([54., 6., 6.]))
+        # np.testing.assert_allclose(x[3], np.array([219., 27., 27.]))
 
 
 if __name__ == "__main__":

--- a/stochrare/tests/test_diffusion.py
+++ b/stochrare/tests/test_diffusion.py
@@ -39,7 +39,12 @@ class TestDynamics(unittest.TestCase):
         x = np.ones((10, 10))
         np.testing.assert_array_equal(self.wiener.potential(x), np.zeros(len(x)))
 
+
     def test_update(self):
+        # Check that _euler_maruyama is called correctly
+        pass
+
+    def test_update_ConstantDiffusionProcess(self):
         for wienerD in (self.wiener, self.wiener1):
             dw = np.random.normal(size=wienerD.dimension)
             x = np.zeros(wienerD.dimension)

--- a/stochrare/tests/test_diffusion.py
+++ b/stochrare/tests/test_diffusion.py
@@ -122,19 +122,6 @@ class TestDynamics(unittest.TestCase):
         np.testing.assert_allclose(x, traj, rtol=1e-5)
 
 
-    def test_euler_maruyama_1d(self):
-        x0 = 1.
-        x = diffusion.DiffusionProcess._euler_maruyama_1d(
-            np.array([x0]*4),
-            np.array(range(3)),
-            np.array([1.,2.,1.]),
-            0.1,
-            jit(lambda x, t: 2*x, nopython=True),
-            jit(lambda x, t: x + t, nopython=True),
-        )
-        np.testing.assert_allclose(x, np.array([1, 2.2, 9.04, 21.888]))
-
-
     def test_euler_maruyama(self):
         # Test DiffusionProcess._euler_maruyama in dimension 3
         x = diffusion.DiffusionProcess._euler_maruyama(
@@ -148,6 +135,17 @@ class TestDynamics(unittest.TestCase):
         np.testing.assert_allclose(x[1], np.array([13., 1., 1.]))
         np.testing.assert_allclose(x[2], np.array([54., 6., 6.]))
         np.testing.assert_allclose(x[3], np.array([219., 27., 27.]))
+
+        x0 = np.array([1.])
+        x = diffusion.DiffusionProcess._euler_maruyama(
+            np.full((4,1), x0),
+            np.array(range(3)),
+            np.array([1.,2.,1.]).reshape(3,1),
+            0.1,
+            jit(lambda x, t: 2*x, nopython=True),
+            jit(lambda x, t: x + t, nopython=True),
+        )
+        np.testing.assert_allclose(x[:,0], np.array([1, 2.2, 9.04, 21.888]))
 
 
 if __name__ == "__main__":

--- a/stochrare/tests/test_diffusion.py
+++ b/stochrare/tests/test_diffusion.py
@@ -125,16 +125,20 @@ class TestDynamics(unittest.TestCase):
         )
         np.testing.assert_allclose(x, np.array([1, 2.2, 9.04, 21.888]))
 
-        # x = diffusion.DiffusionProcess._euler_maruyama(
-        #     np.array([3,0,0]*4, dtype=np.float32).reshape(4,3),
-        #     np.array([1,2,3]),
-        #     1*np.ones((3,3)),
-        #     1.,
 
-        # )
-        # np.testing.assert_allclose(x[1], np.array([13., 1., 1.]))
-        # np.testing.assert_allclose(x[2], np.array([54., 6., 6.]))
-        # np.testing.assert_allclose(x[3], np.array([219., 27., 27.]))
+    def test_euler_maruyama(self):
+        # Test DiffusionProcess._euler_maruyama in dimension 3
+        x = diffusion.DiffusionProcess._euler_maruyama(
+            np.array([3.,0,0]*4).reshape(4,3),
+            np.array([1.,2.,3.]),
+            1.*np.ones((3,3)),
+            1.,
+            jit(lambda x, t: 2*x, nopython=True),
+            jit(lambda x, t: np.diag(x) + t*np.eye(3), nopython=True),
+        )
+        np.testing.assert_allclose(x[1], np.array([13., 1., 1.]))
+        np.testing.assert_allclose(x[2], np.array([54., 6., 6.]))
+        np.testing.assert_allclose(x[3], np.array([219., 27., 27.]))
 
 
 if __name__ == "__main__":

--- a/stochrare/tests/test_diffusion.py
+++ b/stochrare/tests/test_diffusion.py
@@ -41,8 +41,11 @@ class TestDynamics(unittest.TestCase):
 
 
     def test_update(self):
-        # Check that _euler_maruyama is called correctly
-        pass
+        model = diffusion.DiffusionProcess(lambda x, t: 2*x, lambda x, t: np.diag(x)+t*np.eye(3), 3)
+        x = model.update(np.array([1,2,3]), 1., dt=0.01, dw=np.array([0.7]*3))
+        np.testing.assert_almost_equal(x[0], 2.42)
+        np.testing.assert_almost_equal(x[1], 4.14)
+        np.testing.assert_almost_equal(x[2], 5.86)
 
     def test_update_ConstantDiffusionProcess(self):
         for wienerD in (self.wiener, self.wiener1):
@@ -110,18 +113,6 @@ class TestDynamics(unittest.TestCase):
 
 
     def test_euler_maruyama(self):
-        x = diffusion.DiffusionProcess._euler_maruyama(
-            np.array([1,2,3]),
-            1.,
-            0.7*np.ones(3),
-            0.01,
-            lambda x, t: 2*x,
-            lambda x, t: np.diag(x) + t*np.eye(3),
-        )
-        np.testing.assert_almost_equal(x[0], 2.42)
-        np.testing.assert_almost_equal(x[1], 4.14)
-        np.testing.assert_almost_equal(x[2], 5.86)
-
         x = diffusion.DiffusionProcess._euler_maruyama(
             np.array([3,0,0]*4, dtype=np.float32).reshape(4,3),
             np.array([1,2,3]),


### PR DESCRIPTION
This PR extends methods of the `DiffusionProcess` class to processes in one dimension.
The goal was to do so in a way that keeps the code consistent across dimensions, _i.e._ avoiding constructs such as 
```python
if self.dimension == 1:
    return xn + self.drift(xn, tn)*dt+self.diffusion(xn, tn)*dw
else:
    return xn + self.drift(xn, tn)*dt+self.diffusion(xn, tn)@dw
```
The original goal was to provide support for 1D processes without requiring scalars to be converted
to 1D arrays (`x --> np.array([x])`). Particularly, I was relying on `numpy.dot(a,b)` to be equivalent to `a*b` if both `a` and `b` are of type `int` and/or `float`. _This is not the case in the numba version_, and both `a` and `b` must be arrays.

As a result, inputs to `_euler_maruyama` and `update` must be arrays. In the 1D case, users can still provide initials conditions and gaussian increments as scalar, and these will be implicitely converted to 1D arrays:
```python
x0 = 1.
t0 = 0.
t, x = model.trajectory(x0, t0, T=1)
```
The downside is that the return `x` is now an array of shape `(10,1)`:
```bash
>>> print(x)
array([[x0],
       [x1],
       [x2],
       ...)
```

Although this is consistent with higher dimensions (the state of a 1d process is described by a vector of size 1 instead of a scalar), this will be very error prone...