### PR TITLE
1d support for `DiffusionProcess`, take 2

### DIFF
--- a/stochrare/dynamics/diffusion.py
+++ b/stochrare/dynamics/diffusion.py
@@ -69,11 +69,6 @@ class DiffusionProcess:
         self.dimension = dimension
         self.__deterministic__ = kwargs.get('deterministic', False)
 
-        self._euler_maruyama = (
-            self._euler_maruyama_multidim
-            if self.dimension > 1
-            else self._euler_maruyama_1d
-        )
 
     @property
     def drift(self):
@@ -237,7 +232,7 @@ class DiffusionProcess:
         method = kwargs.get('method', 'euler')
         dt = kwargs.get('dt', self.default_dt)
         if method in ('euler', 'euler-maruyama', 'em'):
-            x = self._euler_maruyama(x, t, w, dt, self.drift, self.diffusion)
+            x = self._euler_maruyama(x, t, w, dt)
         else:
             raise NotImplementedError('SDE integration error: Numerical scheme not implemented')
         return x
@@ -308,6 +303,13 @@ class DiffusionProcess:
             tarray = tarray[np.isfinite(x)]
             x = x[np.isfinite(x)]
         return tarray, x
+
+
+    def _euler_maruyama(self, x, t, w, dt):
+        if self.dimension > 1:
+            return self._euler_maruyama_multidim(x, t, w, dt, self.drift, self.diffusion)
+        else:
+            return self._euler_maruyama_1d(x, t, w, dt, self.drift, self.diffusion)
 
 
     @staticmethod

--- a/stochrare/dynamics/diffusion.py
+++ b/stochrare/dynamics/diffusion.py
@@ -269,10 +269,15 @@ class DiffusionProcess:
         if dt < 0:
             raise ValueError("Timestep dt cannot be negative")
         precision = kwargs.pop('precision', np.float32)
-        dim = len(x0)
         num = int(time/dt)+1
         tarray = np.linspace(t0, t0+time, num=num, dtype=precision)
-        x = np.full((num, dim), x0, dtype=precision)
+        if self.dimension == 1:
+            shape_x = (num,)
+            shape_dw = ((num-1)*ratio,)
+        else:
+            shape_x = (num, len(x0))
+            shape_dw = ((num-1)*ratio, len(x0))
+        x = np.full(shape_x, x0, dtype=precision)
         if 'brownian_path' in kwargs:
             tw, w = kwargs.pop('brownian_path')
             dw = np.diff(w, axis=0)
@@ -282,7 +287,7 @@ class DiffusionProcess:
         else:
             deltat = kwargs.pop('deltat', dt)
             ratio = int(np.rint(dt/deltat))
-            dw = np.random.normal(0, np.sqrt(deltat), size=((num-1)*ratio, dim))
+            dw = np.random.normal(0, np.sqrt(deltat), size=shape_dw)
 
             # As of numpy 1.18, random.normal does not support setting the dtype of
             # the returned array (https://github.com/numpy/numpy/issues/10892).

--- a/stochrare/dynamics/diffusion.py
+++ b/stochrare/dynamics/diffusion.py
@@ -280,13 +280,8 @@ class DiffusionProcess:
         precision = kwargs.pop('precision', np.float32)
         num = int(time/dt)+1
         tarray = np.linspace(t0, t0+time, num=num, dtype=precision)
-        if self.dimension == 1:
-            shape_x = (num,)
-            shape_dw = ((num-1)*ratio,)
-        else:
-            shape_x = (num, len(x0))
-            shape_dw = ((num-1)*ratio, len(x0))
-        x = np.full(shape_x, x0, dtype=precision)
+        trajectory_shape = (num,len(x0)) if self.dimension > 1 else (num,)
+        x = np.full(trajectory_shape, x0, dtype=precision)
         if 'brownian_path' in kwargs:
             tw, w = kwargs.pop('brownian_path')
             dw = np.diff(w, axis=0)
@@ -296,7 +291,8 @@ class DiffusionProcess:
         else:
             deltat = kwargs.pop('deltat', dt)
             ratio = int(np.rint(dt/deltat))
-            dw = np.random.normal(0, np.sqrt(deltat), size=shape_dw)
+            brownian_path_shape = ((num-1)*ratio,len(x0)) if self.dimension > 1 else ((num-1)*ratio,)
+            dw = np.random.normal(0, np.sqrt(deltat), size=brownian_path_shape)
 
             # As of numpy 1.18, random.normal does not support setting the dtype of
             # the returned array (https://github.com/numpy/numpy/issues/10892).

--- a/stochrare/dynamics/diffusion.py
+++ b/stochrare/dynamics/diffusion.py
@@ -315,7 +315,7 @@ class DiffusionProcess:
     @staticmethod
     @jit(nopython=True)
     def _euler_maruyama_multidim(x, t, w, dt, drift, diffusion):
-        for index, wn in enumerate(w):
+        for index in range(len(w)):
             wn = w[index]
             xn = x[index]
             tn = t[index]
@@ -326,7 +326,7 @@ class DiffusionProcess:
     @staticmethod
     @jit(nopython=True)
     def _euler_maruyama_1d(x, t, w, dt, drift, diffusion):
-        for index, wn in enumerate(w):
+        for index in range(len(w)):
             wn = w[index]
             xn = x[index]
             tn = t[index]

--- a/stochrare/tests/test_diffusion.py
+++ b/stochrare/tests/test_diffusion.py
@@ -86,17 +86,26 @@ class TestDynamics(unittest.TestCase):
 
 
     def test_integrate_brownian_path(self):
+        func = lambda x,t: x
+        model = diffusion.DiffusionProcess(func, func, 2)
         num = 4
-        dim = 2
         ratio = 3
 
         dw_wrong_shape = np.array([range(1,11), range(11,1,-1)]).transpose()
         with self.assertRaises(ValueError):
-            diffusion.DiffusionProcess._integrate_brownian_path(dw_wrong_shape, num, dim, ratio)
+            model._integrate_brownian_path(dw_wrong_shape, num, ratio)
 
+        # 2d
         dw_correct_shape = np.array([range(1,10), range(10,1,-1)]).transpose()
-        integrated_dw = diffusion.DiffusionProcess._integrate_brownian_path(dw_correct_shape, num, dim, ratio)
+        integrated_dw = model._integrate_brownian_path(dw_correct_shape, num, ratio)
         solution_array = np.array([[6,27],[15,18], [24,9]])
+        np.testing.assert_array_equal(integrated_dw, solution_array)
+
+        # 1d
+        model = diffusion.DiffusionProcess(func, func, 1)
+        dw_correct_shape = np.array(range(1,10))
+        integrated_dw = model._integrate_brownian_path(dw_correct_shape, num, ratio)
+        solution_array = np.array([6, 15, 24])
         np.testing.assert_array_equal(integrated_dw, solution_array)
 
 

--- a/stochrare/tests/test_diffusion.py
+++ b/stochrare/tests/test_diffusion.py
@@ -30,6 +30,8 @@ class TestDynamics(unittest.TestCase):
         self.oup.D0 = 1
         self.oup.theta = 1
         self.oup.mu = 0
+        self.assertEqual(self.wiener._euler_maruyama, diffusion.DiffusionProcess._euler_maruyama_multidim)
+        self.assertEqual(self.wiener1._euler_maruyama, diffusion.DiffusionProcess._euler_maruyama_1d)
 
     def test_potential(self):
         x = np.linspace(-1, 1)


### PR DESCRIPTION
Same objective as for #15 , i.e. make the `DiffusionProcess` class support 1d processes. Particularly the euler-maruyama integration (see #7).
This time the idea is to rely on the attribute `dimension`, introduced in #13 

The main change is the duplication of the `_euler_maruyama_method` into 2 separate jitted methods `euler_maruyama_1d` and `_euler_maruyama_multidim`. A non-static method `_euler_maruyama` is used to redirect to the correct one depending on the value of `self.dimension`.

### Summary of the changes
- In method `trajectory` the shape of trajectory and brownian path arrays is now set dynamically according to dimension attribute.
- `_integrate_brownian_path` is not longer static and the shape of the returned integrated brownian path array depends on the dimension attribute, very much like `trajectory`
- `DiffusionProcess` has a new method `_euler_maruyama` that simply redirects to method `_euler_maruyama_1d` or `_euler_maruyama_multidim` depending on dimension. 