### PR TITLE
I8 add 1d decorator

### DIFF
--- a/stochrare/dynamics/diffusion.py
+++ b/stochrare/dynamics/diffusion.py
@@ -85,6 +85,17 @@ class DiffusionProcess:
     def diffusion(self, diffusionnew):
         self._diffusion = jit(diffusionnew, nopython=True)
 
+    @property
+    def dimension(self):
+        return self._dimension
+
+    @dimension.setter
+    def dimension(self, dimensionnew):
+        if dimensionnew < 1:
+            raise ValueError("Attribute dimension cannot be lower than 1")
+        self._dimension = dimensionnew
+
+
     def potential(self, X, t):
         """
         Compute the potential from which the force derives.

--- a/stochrare/tests/test_diffusion.py
+++ b/stochrare/tests/test_diffusion.py
@@ -29,6 +29,9 @@ class TestDynamics(unittest.TestCase):
         self.oup.D0 = 1
         self.oup.theta = 1
         self.oup.mu = 0
+        self.assertEqual(self.oup.dimension, 2)
+        with self.assertRaises(ValueError):
+            model = diffusion.DiffusionProcess(lambda x,t: x, lambda x,t: x, -1)
 
     def test_potential(self):
         x = np.linspace(-1, 1)

--- a/stochrare/tests/test_utils.py
+++ b/stochrare/tests/test_utils.py
@@ -3,15 +3,38 @@ Unit tests for the utils package.
 """
 import unittest
 import numpy as np
-from stochrare.utils import pseudorand
+from stochrare.utils import pseudorand, one_d_method
+
 
 class TestUtils(unittest.TestCase):
     __deterministic__ = True
 
     @pseudorand
     def test_pseudorand(self):
-        results = np.array([0.54340494, 0.27836939, 0.42451759, 0.84477613, 0.00471886])
+        results = np.array(
+            [
+                0.54340494,
+                0.27836939,
+                0.42451759,
+                0.84477613,
+                0.00471886,
+            ]
+        )
         np.testing.assert_allclose(np.random.random(5), results, atol=1e-8)
+
+    def test_one_d_method(self):
+        class mock_class:
+            def __init__(self, dimension):
+                self.dimension = dimension
+
+            @one_d_method
+            def method(self):
+                return False
+
+        self.assertFalse(mock_class(1).method())
+        with self.assertRaises(NotImplementedError):
+            mock_class(2).method()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/stochrare/tests/test_utils.py
+++ b/stochrare/tests/test_utils.py
@@ -3,7 +3,7 @@ Unit tests for the utils package.
 """
 import unittest
 import numpy as np
-from stochrare.utils import pseudorand, one_d_method
+from stochrare.utils import pseudorand, method1d
 
 
 class TestUtils(unittest.TestCase):
@@ -22,12 +22,12 @@ class TestUtils(unittest.TestCase):
         )
         np.testing.assert_allclose(np.random.random(5), results, atol=1e-8)
 
-    def test_one_d_method(self):
+    def test_method1d(self):
         class mock_class:
             def __init__(self, dimension):
                 self.dimension = dimension
 
-            @one_d_method
+            @method1d
             def method(self):
                 return False
 

--- a/stochrare/utils.py
+++ b/stochrare/utils.py
@@ -13,6 +13,7 @@ This includes decorators, but is not restricted to it.
 import functools
 import numpy as np
 
+
 def pseudorand(fun):
     """
     Decorator for methods of random objects.
@@ -24,12 +25,14 @@ def pseudorand(fun):
 
     The decorator will raise an error if the object does not have a `__deterministic__` attribute.
     """
+
     @functools.wraps(fun)
     def wrapper(*args, **kwargs):
         if args[0].__deterministic__:
             np.random.seed(100)
         retval = fun(*args, **kwargs)
         return retval
+
     return wrapper
 
 
@@ -40,11 +43,16 @@ def one_d_method(fun):
     greater than 1, method is not executed and error is raised.
     Else, method is executed as usual.
     """
+
     @functools.wraps(fun)
     def wrapper(*args, **kwargs):
         if args[0].dimension == 1:
             retval = fun(*args, **kwargs)
             return retval
         else:
-            raise(NotImplementedError)
+            msg = "Method {} is not available for dynamics of dimension 1.".format(
+                fun.__name__
+            )
+            raise NotImplementedError(msg)
+
     return wrapper

--- a/stochrare/utils.py
+++ b/stochrare/utils.py
@@ -9,6 +9,8 @@ but should be used by various other modules in the package.
 This includes decorators, but is not restricted to it.
 
 .. autofunction:: pseudorand
+
+.. autofunction:: method1d
 """
 import functools
 import numpy as np
@@ -36,7 +38,7 @@ def pseudorand(fun):
     return wrapper
 
 
-def one_d_method(fun):
+def method1d(fun):
     """
     Decorator for methods of class DiffusionProcess.
     If the object's `dimension` attribute is set to a value strictly

--- a/stochrare/utils.py
+++ b/stochrare/utils.py
@@ -31,3 +31,20 @@ def pseudorand(fun):
         retval = fun(*args, **kwargs)
         return retval
     return wrapper
+
+
+def one_d_method(fun):
+    """
+    Decorator for methods of class DiffusionProcess.
+    If the object's `dimension` attribute is set to a value strictly
+    greater than 1, method is not executed and error is raised.
+    Else, method is executed as usual.
+    """
+    @functools.wraps(fun)
+    def wrapper(*args, **kwargs):
+        if args[0].dimension == 1:
+            retval = fun(*args, **kwargs)
+            return retval
+        else:
+            raise(NotImplementedError)
+    return wrapper


### PR DESCRIPTION
This adds a new decorator `one_d_method` in `stochrare.utils` that protects methods that should only be available for 1d dynamics.
Caveat: the decorator should only be used on objects that have an attribute dimension.

Additonally, this PR makes the `dimension` attribute of class `DiffusionProcess` a `property`, checking that the dimension is not lower than 1.

Addresses #8 