### PR TITLE
merge DiffusionProcess1D into DiffusionProcess

### DIFF
--- a/stochrare/dynamics/diffusion.py
+++ b/stochrare/dynamics/diffusion.py
@@ -34,7 +34,7 @@ import scipy.integrate as integrate
 from scipy.interpolate import interp1d
 from scipy.misc import derivative
 from numba import jit
-from ..utils import pseudorand, one_d_method
+from ..utils import pseudorand, method1d
 
 class DiffusionProcess:
     r"""
@@ -98,7 +98,7 @@ class DiffusionProcess:
         self._dimension = dimensionnew
 
 
-    @one_d_method
+    @method1d
     def potential(self, X, t):
         """
         Compute the potential from which the force derives.
@@ -354,7 +354,7 @@ class DiffusionProcess:
         return x
 
 
-    @one_d_method
+    @method1d
     def _milstein(self, x, t, w, dt):
         for index, wn in enumerate(w):
             xn = x[index]
@@ -546,7 +546,7 @@ class DiffusionProcess:
             yield (time[0], ) + np.histogram(obs, density=True, **hist_kwargs)
 
 
-    @one_d_method
+    @method1d
     def instantoneq(self, t, Y):
         r"""
         Equations of motion for instanton dynamics.
@@ -585,7 +585,7 @@ class DiffusionProcess:
                          -p**2*self.diffusion(x, t)*dsigmadx-p*dbdx])
 
 
-    @one_d_method
+    @method1d
     def instantoneq_jac(self, t, Y):
         r"""
         Jacobian of the equations of motion for instanton dynamics.
@@ -628,7 +628,7 @@ class DiffusionProcess:
                          [-p*d2bdx2-p**2*(dsigmadx**2+sigma*d2sigmadx2), -dbdx-2*p*sigma*dsigmadx]])
 
 
-    @one_d_method
+    @method1d
     def _fpthsol(self, X, t, **kwargs):
         """ Analytic solution of the Fokker-Planck equation, when it is known.
         In general this is an empty method but subclasses corresponding to stochastic processes
@@ -636,7 +636,7 @@ class DiffusionProcess:
         return NotImplemented
 
 
-    @one_d_method
+    @method1d
     @classmethod
     def trajectoryplot(cls, *args, **kwargs):
         """

--- a/stochrare/dynamics/diffusion.py
+++ b/stochrare/dynamics/diffusion.py
@@ -155,13 +155,8 @@ class DiffusionProcess:
            "Numerical solution of stochastic differential equations", Springer (1992).
         """
         dt = kwargs.get('dt', self.default_dt)
-        if len(xn) != self.dimension:
-            raise ValueError(
-                "State vector xn dimension has dimension {}, expected {}".format(
-                    len(xn), self.dimension
-                )
-            )
-        if self.dimension > 1:
+        dim = self.dimension
+        if dim > 1:
             dw = kwargs.get('dw', np.random.normal(0.0, np.sqrt(dt), dim))
             return xn + self.drift(xn, tn)*dt+self.diffusion(xn, tn) @ dw
         else:

--- a/stochrare/dynamics/diffusion.py
+++ b/stochrare/dynamics/diffusion.py
@@ -291,11 +291,10 @@ class DiffusionProcess:
 
             # As of numpy 1.18, random.normal does not support setting the dtype of
             # the returned array (https://github.com/numpy/numpy/issues/10892).
-            # We cast dw to the same type returned by the diffusion function to prevent a numba
+            # We cast dw to the type of the state vector "x" to prevent a numba
             # TypingError in self._euler_maruyama.
             # See issue https://github.com/cbherbert/stochrare/issues/14
-            returned_array = self.diffusion(x[0], tarray[0])
-            dw = dw.astype(returned_array.dtype)
+            dw = dw.astype(x.dtype)
 
         dw = self._integrate_brownian_path(dw, num, ratio)
         x = self.integrate_sde(x, tarray, dw, dt=dt, **kwargs)

--- a/stochrare/dynamics/diffusion.py
+++ b/stochrare/dynamics/diffusion.py
@@ -311,10 +311,11 @@ class DiffusionProcess:
 
             # As of numpy 1.18, random.normal does not support setting the dtype of
             # the returned array (https://github.com/numpy/numpy/issues/10892).
-            # We cast dw to the type of the state vector "x" to prevent a numba
+            # We cast dw to the same type returned by the diffusion function to prevent a numba
             # TypingError in self._euler_maruyama.
             # See issue https://github.com/cbherbert/stochrare/issues/14
-            dw = dw.astype(x.dtype)
+            returned_array = self.diffusion(x[0], tarray[0])
+            dw = dw.astype(returned_array.dtype)
 
         dw = self._integrate_brownian_path(dw, num, ratio)
         x = self.integrate_sde(x, tarray, dw, dt=dt, **kwargs)

--- a/stochrare/dynamics/diffusion.py
+++ b/stochrare/dynamics/diffusion.py
@@ -98,6 +98,7 @@ class DiffusionProcess:
         self._dimension = dimensionnew
 
 
+    @one_d_method
     def potential(self, X, t):
         """
         Compute the potential from which the force derives.
@@ -122,6 +123,7 @@ class DiffusionProcess:
             raise ValueError('Generic dynamics in arbitrary dimensions are not gradient dynamics!')
         fun = interp1d(X, -1*self.drift(X, t), fill_value='extrapolate')
         return np.array([integrate.quad(fun, 0.0, x)[0] for x in X])
+
 
     def update(self, xn, tn, **kwargs):
         r"""
@@ -352,6 +354,7 @@ class DiffusionProcess:
         return x
 
 
+    @one_d_method
     @staticmethod
     def _milstein(x, t, w, dt, drift, diffusion):
         for index, wn in enumerate(w):
@@ -479,6 +482,7 @@ class DiffusionProcess:
             yield np.average(time, axis=0), np.average(obs, axis=0)
 
 
+    @one_d_method
     def _instantoneq(self, t, Y):
         r"""
         Equations of motion for instanton dynamics.
@@ -517,6 +521,7 @@ class DiffusionProcess:
                          -p**2*self.diffusion(x, t)*dsigmadx-p*dbdx])
 
 
+    @one_d_method
     def _instantoneq_jac(self, t, Y):
         r"""
         Jacobian of the equations of motion for instanton dynamics.
@@ -559,6 +564,7 @@ class DiffusionProcess:
                          [-p*d2bdx2-p**2*(dsigmadx**2+sigma*d2sigmadx2), -dbdx-2*p*sigma*dsigmadx]])
 
 
+    @one_d_method
     def _fpthsol(self, X, t, **kwargs):
         """ Analytic solution of the Fokker-Planck equation, when it is known.
         In general this is an empty method but subclasses corresponding to stochastic processes
@@ -566,6 +572,7 @@ class DiffusionProcess:
         return NotImplemented
 
 
+    @one_d_method
     @classmethod
     def trajectoryplot(cls, *args, **kwargs):
         """

--- a/stochrare/dynamics/diffusion.py
+++ b/stochrare/dynamics/diffusion.py
@@ -155,9 +155,18 @@ class DiffusionProcess:
            "Numerical solution of stochastic differential equations", Springer (1992).
         """
         dt = kwargs.get('dt', self.default_dt)
-        dim = len(xn)
-        dw = kwargs.get('dw', np.random.normal(0.0, np.sqrt(dt), dim))
-        return xn + self.drift(xn, tn)*dt+self.diffusion(xn, tn)@dw
+        if len(xn) != self.dimension:
+            raise ValueError(
+                "State vector xn dimension has dimension {}, expected {}".format(
+                    len(xn), self.dimension
+                )
+            )
+        if self.dimension > 1:
+            dw = kwargs.get('dw', np.random.normal(0.0, np.sqrt(dt), dim))
+            return xn + self.drift(xn, tn)*dt+self.diffusion(xn, tn) @ dw
+        else:
+            dw = kwargs.get('dw', np.random.normal(0.0, np.sqrt(dt)))
+            return xn + self.drift(xn, tn)*dt+self.diffusion(xn, tn) * dw
 
 
     def _integrate_brownian_path(self, dw, num, ratio):

--- a/stochrare/dynamics/diffusion.py
+++ b/stochrare/dynamics/diffusion.py
@@ -34,7 +34,7 @@ import scipy.integrate as integrate
 from scipy.interpolate import interp1d
 from scipy.misc import derivative
 from numba import jit
-from ..utils import pseudorand
+from ..utils import pseudorand, one_d_method
 
 class DiffusionProcess:
     r"""

--- a/stochrare/dynamics/diffusion.py
+++ b/stochrare/dynamics/diffusion.py
@@ -443,6 +443,7 @@ class DiffusionProcess:
                 break
         return t, x
 
+
     def sample_mean(self, x0, t0, nsteps, nsamples, **kwargs):
         r"""
         Compute the sample mean of a time dependent observable, conditioned on initial conditions.
@@ -481,9 +482,8 @@ class DiffusionProcess:
             yield np.average(time, axis=0), np.average(obs, axis=0)
 
 
-    @one_d_method
     def empirical_vector(self, x0, t0, nsamples, *args, **kwargs):
-        """
+        r"""
         Empirical vector at given times.
 
         Parameters
@@ -517,12 +517,31 @@ class DiffusionProcess:
         hist_kwargs_keys = ('bins', 'range', 'weights') # hard-coded for now, we might use inspect
         hist_kwargs = {key: kwargs[key] for key in kwargs if key in hist_kwargs_keys}
         def traj_sample(x0, t0, *args, **kwargs):
-            for tsample in args:
+            if 'brownian_path' in kwargs:
+                tw, w = kwargs.pop('brownian_path', None)
+                dt = kwargs.get('dt', self.default_dt)
+                offset=0
+            for i, tsample in enumerate(args):
+                if 'brownian_path' in kwargs:
+                    deltat = tw[1]-tw[0]
+                    num = int((tsample-t0)/deltat)+1
+                    brownian_path_chunk = brownian_path[offset:num+offset]
+                    offset = num
+                    kwargs.update({'brownian_path': brownian_path_chunk})
                 t, x = self.trajectory(x0, t0, T=tsample-t0, **kwargs)
                 t0 = t[-1]
                 x0 = x[-1]
                 yield tsample, x0
-        for ensemble in zip(*[traj_sample(x0, t0, *args, **kwargs) for _ in range(nsamples)]):
+
+
+        brownian_paths = kwargs.pop('brownian_paths', None)
+        traj_ensemble = []
+        for sample in range(nsamples):
+            if brownian_paths:
+                kwargs.update({'brownian_path': brownian_paths[sample]})
+            traj_ensemble.append(traj_sample(x0, t0, *args, **kwargs))
+
+        for ensemble in zip(*traj_ensemble):
             time, obs = zip(*ensemble)
             yield (time[0], ) + np.histogram(obs, density=True, **hist_kwargs)
 

--- a/stochrare/dynamics/diffusion.py
+++ b/stochrare/dynamics/diffusion.py
@@ -32,6 +32,7 @@ These classes form a hierarchy deriving from the base class, `DiffusionProcess`.
 import numpy as np
 import scipy.integrate as integrate
 from scipy.interpolate import interp1d
+from scipy.misc import derivative
 from numba import jit
 from ..utils import pseudorand
 
@@ -341,16 +342,14 @@ class DiffusionProcess:
 
 
     @staticmethod
-    @jit(nopython=True)
     def _milstein(x, t, w, dt, drift, diffusion):
-        index = 1
         for index, wn in enumerate(w):
-            xn = x[index-1]
-            tn = t[index-1]
+            xn = x[index]
+            tn = t[index]
             a = drift(xn, tn)
             b = diffusion(xn, tn)
-            db = derivative(diffusion, xn, dx=1e-6, args=(t, ))
-            x[index] = xn + (a-0.5*b*db)*dt + b*wn + 0.5*b*db*wn**2
+            db = derivative(diffusion, xn, dx=1e-6, args=(tn,))
+            x[index+1] = xn + (a-0.5*b*db)*dt + b*wn + 0.5*b*db*wn**2
         return x
 
 

--- a/stochrare/dynamics/diffusion.py
+++ b/stochrare/dynamics/diffusion.py
@@ -467,6 +467,40 @@ class DiffusionProcess:
             time, obs = zip(*ensemble)
             yield np.average(time, axis=0), np.average(obs, axis=0)
 
+
+    @classmethod
+    def trajectoryplot(cls, *args, **kwargs):
+        """
+        Plot 1D  trajectories.
+
+        Parameters
+        ----------
+        *args : variable length argument list
+        trajs: tuple (t, x)
+
+        Keyword Arguments
+        -----------------
+        fig : matplotlig.figure.Figure
+            Figure object to use for the plot. Create one if not provided.
+        ax : matplotlig.axes.Axes
+            Axes object to use for the plot. Create one if not provided.
+        **kwargs :
+            Other keyword arguments forwarded to matplotlib.pyplot.axes.
+
+        Returns
+        -------
+        fig, ax: matplotlib.figure.Figure, matplotlib.axes.Axes
+            The figure.
+
+        Notes
+        -----
+        This is just an interface to the function :meth:`stochrare.io.plot.trajectory_plot1d`.
+        However, it may be overwritten in subclasses to systematically include elements to
+        the plot which are specific to the stochastic process.
+        """
+        return plot.trajectory_plot1d(*args, **kwargs)
+
+
 class ConstantDiffusionProcess(DiffusionProcess):
     r"""
     Diffusion processes, in arbitrary dimensions, with constant diffusion coefficient.

--- a/stochrare/dynamics/diffusion.py
+++ b/stochrare/dynamics/diffusion.py
@@ -518,15 +518,15 @@ class DiffusionProcess:
         hist_kwargs = {key: kwargs[key] for key in kwargs if key in hist_kwargs_keys}
         def traj_sample(x0, t0, *args, **kwargs):
             if 'brownian_path' in kwargs:
-                tw, w = kwargs.pop('brownian_path', None)
+                tw, w = kwargs.get('brownian_path')
                 dt = kwargs.get('dt', self.default_dt)
                 offset=0
             for i, tsample in enumerate(args):
                 if 'brownian_path' in kwargs:
                     deltat = tw[1]-tw[0]
                     num = int((tsample-t0)/deltat)+1
-                    brownian_path_chunk = brownian_path[offset:num+offset]
-                    offset = num
+                    brownian_path_chunk = (tw[offset:num+offset], w[offset:num+offset])
+                    offset = num + offset - 1
                     kwargs.update({'brownian_path': brownian_path_chunk})
                 t, x = self.trajectory(x0, t0, T=tsample-t0, **kwargs)
                 t0 = t[-1]

--- a/stochrare/dynamics/diffusion.py
+++ b/stochrare/dynamics/diffusion.py
@@ -393,6 +393,43 @@ class DiffusionProcess:
             x = self.update(x, t, dt=dt)
             yield t, obs(x, t)
 
+
+    def trajectory_conditional(self, x0, t0, pred, **kwargs):
+        r"""
+        Compute sample path satisfying arbitrary condition.
+
+        Parameters
+        ----------
+        x0: float
+            The initial position.
+        t0: float
+            The initial time.
+        pred: function with two arguments
+            The predicate to select trajectories.
+
+        Keyword Arguments
+        -----------------
+        dt: float
+            The time step, forwarded to the :meth:`update` routine
+            (default 0.1, unless overridden by a subclass).
+        T: float
+            The time duration of the trajectory (default 10).
+        finite: bool
+            Filter finite values before returning trajectory (default False).
+
+        Returns
+        -------
+        t, x: ndarray, ndarray
+            Time-discrete sample path for the stochastic process with initial conditions (t0, x0).
+            The array t contains the time discretization and x the value of the sample path
+            at these instants.
+        """
+        while True:
+            t, x = self.trajectory(x0, t0, **kwargs)
+            if pred(t, x):
+                break
+        return t, x
+
     def sample_mean(self, x0, t0, nsteps, nsamples, **kwargs):
         r"""
         Compute the sample mean of a time dependent observable, conditioned on initial conditions.

--- a/stochrare/dynamics/diffusion.py
+++ b/stochrare/dynamics/diffusion.py
@@ -483,7 +483,7 @@ class DiffusionProcess:
 
 
     @one_d_method
-    def _instantoneq(self, t, Y):
+    def instantoneq(self, t, Y):
         r"""
         Equations of motion for instanton dynamics.
 
@@ -522,7 +522,7 @@ class DiffusionProcess:
 
 
     @one_d_method
-    def _instantoneq_jac(self, t, Y):
+    def instantoneq_jac(self, t, Y):
         r"""
         Jacobian of the equations of motion for instanton dynamics.
 

--- a/stochrare/dynamics/diffusion.py
+++ b/stochrare/dynamics/diffusion.py
@@ -559,6 +559,13 @@ class DiffusionProcess:
                          [-p*d2bdx2-p**2*(dsigmadx**2+sigma*d2sigmadx2), -dbdx-2*p*sigma*dsigmadx]])
 
 
+    def _fpthsol(self, X, t, **kwargs):
+        """ Analytic solution of the Fokker-Planck equation, when it is known.
+        In general this is an empty method but subclasses corresponding to stochastic processes
+        for which theoretical results exists should override it."""
+        return NotImplemented
+
+
     @classmethod
     def trajectoryplot(cls, *args, **kwargs):
         """

--- a/stochrare/dynamics/diffusion.py
+++ b/stochrare/dynamics/diffusion.py
@@ -482,6 +482,52 @@ class DiffusionProcess:
 
 
     @one_d_method
+    def empirical_vector(self, x0, t0, nsamples, *args, **kwargs):
+        """
+        Empirical vector at given times.
+
+        Parameters
+        ----------
+        x0 : float
+            Initial position.
+        t0 : float
+            Initial time.
+        nsamples : int
+            The size of the ensemble.
+        *args : variable length argument list
+            The times at which we want to estimate the empirical vector.
+
+        Keyword Arguments
+        -----------------
+        **kwargs :
+            Keyword arguments forwarded to :meth:`trajectory` and to :meth:`numpy.histogram`.
+
+        Yields
+        ------
+        t, pdf, bins : float, ndarray, ndarray
+            The time and histogram of the stochastic process at that time.
+
+        Notes
+        -----
+        This method computes the empirical vector, or in other words, the relative frequency of the
+        stochastic process at different times, conditioned on the initial condition.
+        At each time, the empirical vector is a random vector.
+        It is an estimator of the transition probability :math:`p(x, t | x_0, t_0)`.
+        """
+        hist_kwargs_keys = ('bins', 'range', 'weights') # hard-coded for now, we might use inspect
+        hist_kwargs = {key: kwargs[key] for key in kwargs if key in hist_kwargs_keys}
+        def traj_sample(x0, t0, *args, **kwargs):
+            for tsample in args:
+                t, x = self.trajectory(x0, t0, T=tsample-t0, **kwargs)
+                t0 = t[-1]
+                x0 = x[-1]
+                yield tsample, x0
+        for ensemble in zip(*[traj_sample(x0, t0, *args, **kwargs) for _ in range(nsamples)]):
+            time, obs = zip(*ensemble)
+            yield (time[0], ) + np.histogram(obs, density=True, **hist_kwargs)
+
+
+    @one_d_method
     def instantoneq(self, t, Y):
         r"""
         Equations of motion for instanton dynamics.

--- a/stochrare/dynamics/diffusion.py
+++ b/stochrare/dynamics/diffusion.py
@@ -251,8 +251,8 @@ class DiffusionProcess:
         dt = kwargs.get('dt', self.default_dt)
         if method in ('euler', 'euler-maruyama', 'em'):
             x = self._euler_maruyama(x, t, w, dt)
-        elif method=='milstein':
-            x = self._milstein(x, t, w, dt, self.drift, self.diffusion)
+        elif method == 'milstein':
+            x = self._milstein(x, t, w, dt)
         else:
             raise NotImplementedError('SDE integration error: Numerical scheme not implemented')
         return x
@@ -354,14 +354,13 @@ class DiffusionProcess:
 
 
     @one_d_method
-    @staticmethod
-    def _milstein(x, t, w, dt, drift, diffusion):
+    def _milstein(self, x, t, w, dt):
         for index, wn in enumerate(w):
             xn = x[index]
             tn = t[index]
-            a = drift(xn, tn)
-            b = diffusion(xn, tn)
-            db = derivative(diffusion, xn, dx=1e-6, args=(tn,))
+            a = self.drift(xn, tn)
+            b = self.diffusion(xn, tn)
+            db = derivative(self.diffusion, xn, dx=1e-6, args=(tn,))
             x[index+1] = xn + (a-0.5*b*db)*dt + b*wn + 0.5*b*db*wn**2
         return x
 

--- a/stochrare/tests/test_diffusion.py
+++ b/stochrare/tests/test_diffusion.py
@@ -258,13 +258,13 @@ class TestDynamics(unittest.TestCase):
             np.testing.assert_allclose(bins, expected_bins)
 
 
-    def test_instantoneq(self):
+    def testinstantoneq(self):
         model = diffusion.DiffusionProcess(lambda x, t: 2*x, lambda x, t: x, 1)
 
         xvec = np.linspace(-1,1,10)
         pvec = np.linspace(-1,1,10)
 
-        instantoneq = np.array([model._instantoneq(0, [x,p]) for x,p in zip(xvec, pvec)])
+        instantoneq = np.array([model.instantoneq(0, [x,p]) for x,p in zip(xvec, pvec)])
         # instantoneq =  [[-3.          3.        ]
         #                 [-2.0260631   2.0260631 ]
         #                 [-1.28257888  1.28257888]
@@ -282,13 +282,13 @@ class TestDynamics(unittest.TestCase):
         np.testing.assert_allclose(instantoneq[:,1], expected_pdot)
 
 
-    def test_instantoneq_jac(self):
+    def testinstantoneq_jac(self):
         model = diffusion.DiffusionProcess(lambda x, t: 2 * x, lambda x, t: x, 1)
 
         xvec = np.linspace(-1, 1, 10)
         pvec = np.linspace(-1, 1, 10)
 
-        instantoneq_jac = [model._instantoneq_jac(0, [x, p]) for x, p in zip(xvec, pvec)]
+        instantoneq_jac = [model.instantoneq_jac(0, [x, p]) for x, p in zip(xvec, pvec)]
 
         expected_J11 = lambda x, p: 2 * x * p + 2
         expected_J12 = lambda x, p: x * x

--- a/stochrare/tests/test_diffusion.py
+++ b/stochrare/tests/test_diffusion.py
@@ -337,14 +337,13 @@ class TestDynamics(unittest.TestCase):
         np.testing.assert_allclose(x, np.array([1, 2.2, 9.04, 21.888]))
 
     def test_milstein(self):
-        x0=1.
-        x = diffusion.DiffusionProcess._milstein(
+        model = diffusion.DiffusionProcess(lambda x, t: 2*x, lambda x, t: x + t, 1)
+        x0 = 1.
+        x = model._milstein(
             np.full((4,), x0),
             np.array(range(3)),
             np.array([1.,2.,1.]),
             0.1,
-            lambda x, t: 2*x,
-            lambda x, t: x + t,
             )
         np.testing.assert_allclose(x, [1., 2.65, 17.5975, 49.53337501])
 

--- a/stochrare/tests/test_diffusion.py
+++ b/stochrare/tests/test_diffusion.py
@@ -272,6 +272,11 @@ class TestDynamics(unittest.TestCase):
         np.testing.assert_allclose(instantoneq_jac, expected, atol=1e-5)
 
 
+    @unittest.skip("Method not yet implemented")
+    def test_fpthsol(self):
+        raise NotImplementedError
+
+
     def test_euler_maruyama(self):
         # Test DiffusionProcess._euler_maruyama in dimension 3
         x = diffusion.DiffusionProcess._euler_maruyama_multidim(

--- a/stochrare/tests/test_diffusion.py
+++ b/stochrare/tests/test_diffusion.py
@@ -208,6 +208,20 @@ class TestDynamics(unittest.TestCase):
         np.testing.assert_allclose(x, traj, rtol=1e-5)
 
 
+    def test_trajectory_conditional(self):
+        def pred(t,x):
+            Xp = [np.dot(xi,xi) for xi in x[t>0.5]]
+            Xm = [np.dot(xi,xi) for xi in x[t<0.5]]
+            return np.mean(Xp) > np.mean(Xm)
+
+        x0 = np.array([0.,0.])
+        t, x = self.oup.trajectory_conditional(x0, 0, pred, T=1)
+
+        Xp = [np.dot(xi,xi) for xi in x[t>0.5]]
+        Xm = [np.dot(xi,xi) for xi in x[t<0.5]]
+        self.assertTrue(np.mean(Xp) > np.mean(Xm))
+
+
     def test_euler_maruyama(self):
         # Test DiffusionProcess._euler_maruyama in dimension 3
         x = diffusion.DiffusionProcess._euler_maruyama_multidim(

--- a/stochrare/tests/test_diffusion.py
+++ b/stochrare/tests/test_diffusion.py
@@ -234,6 +234,18 @@ class TestDynamics(unittest.TestCase):
         )
         np.testing.assert_allclose(x, np.array([1, 2.2, 9.04, 21.888]))
 
+    def test_milstein(self):
+        x0=1.
+        x = diffusion.DiffusionProcess._milstein(
+            np.full((4,), x0),
+            np.array(range(3)),
+            np.array([1.,2.,1.]),
+            0.1,
+            lambda x, t: 2*x,
+            lambda x, t: x + t,
+            )
+        np.testing.assert_allclose(x, [1., 2.65, 17.5975, 49.53337501])
+
 
 class TestOrnsteinUlhenbeckProcess(unittest.TestCase):
     def setUp(self):

--- a/stochrare/tests/test_diffusion.py
+++ b/stochrare/tests/test_diffusion.py
@@ -70,13 +70,6 @@ class TestDynamics(unittest.TestCase):
         x = np.ones((10, 10))
         np.testing.assert_array_equal(self.wiener.potential(x), np.zeros(len(x)))
 
-    def test_update(self):
-        for wienerD in (self.wiener, self.wiener1):
-            dw = np.random.normal(size=wienerD.dimension)
-            x = np.zeros(wienerD.dimension)
-            np.testing.assert_array_equal(wienerD.update(x, 0, dw=dw), dw)
-            np.testing.assert_array_equal(diffusion.DiffusionProcess.update(wienerD, x, 0, dw=dw),
-                                          dw)
 
     @patch.object(diffusion.DiffusionProcess, "_euler_maruyama")
     def test_integrate_sde(self, mock_DiffusionProcess):
@@ -240,6 +233,21 @@ class TestDynamics(unittest.TestCase):
             jit(lambda x, t: x + t, nopython=True),
         )
         np.testing.assert_allclose(x, np.array([1, 2.2, 9.04, 21.888]))
+
+
+class TestOrnsteinUlhenbeckProcess(unittest.TestCase):
+    def setUp(self):
+        self.oup = diffusion.OrnsteinUhlenbeck(0, 1, 1, 2, deterministic=True)
+        self.wiener = diffusion.Wiener(2, D=0.5, deterministic=True)
+        self.wiener1 = diffusion.Wiener(1, D=0.5, deterministic=True)
+
+
+    def test_update(self):
+        for wienerD in (self.wiener, self.wiener1):
+            dw = np.random.normal(size=wienerD.dimension)
+            x = np.zeros(wienerD.dimension)
+            np.testing.assert_array_equal(wienerD.update(x, 0, dw=dw), dw)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/stochrare/tests/test_diffusion.py
+++ b/stochrare/tests/test_diffusion.py
@@ -13,6 +13,22 @@ class TestDynamics(unittest.TestCase):
         self.wiener = diffusion.Wiener(2, D=0.5, deterministic=True)
         self.wiener1 = diffusion.Wiener(1, D=0.5, deterministic=True)
 
+
+        self.diffusions = []
+        self.diffusions.append(diffusion.DiffusionProcess(lambda x, t: 2*x,
+                                                          lambda x, t: 1,
+                                                          1,
+                                                          deterministic=True))
+        self.diffusions.append(diffusion.DiffusionProcess(lambda x, t: 2*x,
+                                                          lambda x, t: np.identity(2),
+                                                          2,
+                                                          deterministic=True))
+        self.diffusions.append(diffusion.DiffusionProcess(lambda x, t: 2*x,
+                                                          lambda x, t: np.identity(3),
+                                                          3,
+                                                          deterministic=True))
+
+
     def test_properties(self):
         self.assertEqual(self.oup.D0, 1)
         self.assertEqual(self.oup.mu, 0)
@@ -30,6 +46,19 @@ class TestDynamics(unittest.TestCase):
         self.oup.D0 = 1
         self.oup.theta = 1
         self.oup.mu = 0
+
+
+    def test_update(self):
+        x = 0.0
+        dw = np.random.normal(1)
+        result = self.diffusions[0].update(x, 0, dw=dw)
+        np.testing.assert_equal(result, dw)
+
+        for model in self.diffusions[1:]:
+            x = np.zeros(shape=model.dimension)
+            dw = np.random.normal(size=model.dimension)
+            result = model.update(x, 0, dw=dw)
+            np.testing.assert_array_equal(result, dw)
 
 
     def test_potential(self):

--- a/stochrare/tests/test_diffusion.py
+++ b/stochrare/tests/test_diffusion.py
@@ -2,8 +2,10 @@
 Unit tests for the diffusion module.
 """
 import unittest
+import inspect
 import numpy as np
 import stochrare.dynamics.diffusion as diffusion
+import stochrare.dynamics.diffusion1d as diffusion1d
 from unittest.mock import patch
 from numba import jit
 
@@ -11,7 +13,7 @@ class TestDynamics(unittest.TestCase):
     def setUp(self):
         self.oup = diffusion.OrnsteinUhlenbeck(0, 1, 1, 2, deterministic=True)
         self.wiener = diffusion.Wiener(2, D=0.5, deterministic=True)
-        self.wiener1 = diffusion.Wiener(1, D=0.5, deterministic=True)
+        self.wiener1 = diffusion1d.Wiener1D(D=0.5, deterministic=True)
 
 
         self.diffusions = []
@@ -224,7 +226,25 @@ class TestDynamics(unittest.TestCase):
         Xm = [np.dot(xi,xi) for xi in x[t<0.5]]
         self.assertTrue(np.mean(Xp) > np.mean(Xm))
 
+        
+    def test_empirical_vector(self):
+        model = diffusion.DiffusionProcess(lambda x, t: 2*x, lambda x, t: x, 1)
+        dt_brownian = 0.01
+        nsamples = 1
+        brownian_paths = [
+            self.wiener1.trajectory(1.,0.,T=1, dt=dt_brownian) for sample in range(nsamples)
+        ]
+        for (t, pdf, bins) in model.empirical_vector(1., 0., nsamples, 1.):
+            print(t)
 
+        trajs_exact = [np.exp(1.5*bp[0]+bp[1]) for bp in brownian_paths]
+        
+            
+            
+        
+            
+
+        
     def test_instantoneq(self):
         model = diffusion.DiffusionProcess(lambda x, t: 2*x, lambda x, t: x, 1)
 


### PR DESCRIPTION
_Edit 01/07/2020_
This PR grew larger than just extending `DiffusionProcess.update`. It ports all methods from the specialised 1d class `DiffusionProcess1D` to the general class `DiffusionProcess`, using the `@method1d` decorator to restrict some of them to process in 1D

---------------------------------------------------------------------------------

At the moment it is assumed that if `DiffusionProcess.update` is called from a process with `dimension=1`, then the state vector is an array of size 1.
This adds a conditial in `DiffusionProcess.update` to make update return a `float` for `1d processes.

I chose not the check the dimesion with something like
```python
if len(xn) != self.dimension:
  raise ValueError("State vector xn has dimension {}, expected {}".format(len(xn), self.dimension))
```
Reasons:
- If `update` is intended to be mostly called internally, it's not required
- It may hurt performance if `update` is called repeatedly
- If `xn` is `float` then `len(xn)` does not exist, so must first use extra `np.atleast1d` which adds complexity.

