### PR TITLE
Simplify empirical vector

### DIFF
--- a/stochrare/dynamics/diffusion.py
+++ b/stochrare/dynamics/diffusion.py
@@ -481,7 +481,7 @@ class DiffusionProcess:
             yield np.average(time, axis=0), np.average(obs, axis=0)
 
 
-    @one_d_method
+    @method1d
     def empirical_vector(self, x0, t0, nsamples, *args, **kwargs):
         r"""
         Empirical vector at given times.

--- a/stochrare/dynamics/diffusion.py
+++ b/stochrare/dynamics/diffusion.py
@@ -443,6 +443,7 @@ class DiffusionProcess:
                 break
         return t, x
 
+
     def sample_mean(self, x0, t0, nsteps, nsamples, **kwargs):
         r"""
         Compute the sample mean of a time dependent observable, conditioned on initial conditions.


### PR DESCRIPTION
Change the way `DiffusionProcess.empirical_vector` is tested allowing to simplify the method itself (roll it back to the `DiffusionProcess1D` version).

The test currently implemented in branch `merge_diffusion1d.DiffusionProcess` compares the empirical vector computed from the theoretical solution. This requires the `empirical_vector` method to be able to receive the brownian paths for each sample trajectory, and use these brownian paths when calling `trajectory`. Maybe there's a better way to do it, but it currently adds a lot of complexity compared to the original implementation of `DiffusionProcess1D.empirical_vector`.

This PR changes the test for `empirical_vector` so as to test the result of the method against the empirical vector computed explicitly (by calling `trajectory` `nsamples` times). This assumes that the method `trajectory` is correct, but it is independently tested against the theoretical solution in other tests.